### PR TITLE
Change integer columns to decimals

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
+  include ActionView::Helpers::NumberHelper
   self.abstract_class = true
+
+  def strip_zeros(number)
+    number_with_precision(number, precision: 2, strip_insignificant_zeros: true)
+  end
 end

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -22,9 +22,9 @@ class Estimate < ApplicationRecord
 
   def number_text
     if poker_session.timebox?
-      "#{number} days"
+      "#{strip_zeros(number)} days"
     else
-      number
+      strip_zeros(number)
     end
   end
 end

--- a/app/models/poker_session.rb
+++ b/app/models/poker_session.rb
@@ -51,9 +51,9 @@ class PokerSession < ApplicationRecord
 
   def result_text
     if timebox?
-      "#{result} #{'day'.pluralize(result)}"
+      "#{strip_zeros(result)} #{'day'.pluralize(result)}"
     else
-      result
+      strip_zeros(result)
     end
   end
 

--- a/db/migrate/20181211110137_change_integers_to_decimal.rb
+++ b/db/migrate/20181211110137_change_integers_to_decimal.rb
@@ -1,0 +1,6 @@
+class ChangeIntegersToDecimal < ActiveRecord::Migration[5.2]
+  def change
+    change_column :estimates, :number, :decimal, precision: 8, scale: 2
+    change_column :poker_sessions, :result, :decimal, precision: 8, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_19_114209) do
+ActiveRecord::Schema.define(version: 2018_12_11_110137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "estimates", force: :cascade do |t|
-    t.integer "number"
+    t.decimal "number", precision: 8, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "poker_session_id"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2018_11_19_114209) do
 
   create_table "poker_sessions", force: :cascade do |t|
     t.boolean "completed"
-    t.integer "result"
+    t.decimal "result", precision: 8, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "story_name"

--- a/lib/poker_slack_message.rb
+++ b/lib/poker_slack_message.rb
@@ -59,7 +59,6 @@ class PokerSlackMessage
     ]
   end
 
-
   def request
     {
       text: story_name,

--- a/spec/models/poker_session/effort_spec.rb
+++ b/spec/models/poker_session/effort_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 RSpec.describe PokerSession::Effort do
   subject(:poker_session) { FactoryBot.create(:effort_poker_session, story_name: 'Testing poker sessions') }
   describe '#scores' do
-    its(:scores) { is_expected.to eq [1, 2, 3, 5, 8, 13, 20, 40, 100] }
+    its(:scores) { is_expected.to eq [0, 1, 2, 3, 5, 8, 13, 20, 40, 100] }
   end
 
   describe '#closest_story_number_to_average' do

--- a/spec/models/poker_session/timebox_spec.rb
+++ b/spec/models/poker_session/timebox_spec.rb
@@ -20,20 +20,29 @@ RSpec.describe PokerSession::Timebox do
 
   describe '#closest_story_number_to_average' do
     context 'when 3.5 Days and a 1 Day are voted for' do
-      let!(:estimate3) { FactoryBot.create(:estimate, number: 1, poker_session: poker_session) }
-      let!(:estimate5) { FactoryBot.create(:estimate, number: 3.5, poker_session: poker_session) }
+      let!(:estimate1) { FactoryBot.create(:estimate, number: 1, poker_session: poker_session) }
+      let!(:estimate2) { FactoryBot.create(:estimate, number: 3.5, poker_session: poker_session) }
 
       it 'will return 2.0' do
-        expect(poker_session.closest_story_number_to_average).to eq 2.0
+        expect(poker_session.closest_story_number_to_average).to eq 2.5
       end
     end
 
     context 'when 0.5 Days and a 5 Days are voted for' do
-      let!(:estimate3) { FactoryBot.create(:estimate, number: 0.5, poker_session: poker_session) }
-      let!(:estimate5) { FactoryBot.create(:estimate, number: 5, poker_session: poker_session) }
+      let!(:estimate1) { FactoryBot.create(:estimate, number: 0.5, poker_session: poker_session) }
+      let!(:estimate2) { FactoryBot.create(:estimate, number: 5, poker_session: poker_session) }
 
-      it 'will return 2.0' do
-        expect(poker_session.closest_story_number_to_average).to eq 2.5
+      it 'will return 2.5' do
+        expect(poker_session.closest_story_number_to_average).to eq 3.0
+      end
+    end
+
+    context 'with decimals voted' do
+      let!(:estimate1) {  FactoryBot.create(:estimate, number: 3.5, poker_session: poker_session)  }
+      let!(:estimate2) {  FactoryBot.create(:estimate, number: 3.5, poker_session: poker_session)  }
+
+      it 'will return 3.5' do
+        expect(poker_session.closest_story_number_to_average).to eq 3.5
       end
     end
   end
@@ -41,13 +50,24 @@ RSpec.describe PokerSession::Timebox do
   describe '#complete_session_text' do
     let(:user1) { FactoryBot.create(:user, name: 'jerome') }
     let(:user2) { FactoryBot.create(:user, name: 'callum') }
-    let!(:estimate3) { FactoryBot.create(:estimate, number: 3, poker_session: poker_session, user: user1) }
-    let!(:estimate5) { FactoryBot.create(:estimate, number: 5, poker_session: poker_session, user: user2) }
+    context 'with a decimal average' do
 
-    it 'will return the correct text' do
-      poker_session.complete_session
-      expect(poker_session.complete_session_text).to eq "*Testing poker sessions*\njerome voted 3 days and callum voted 5 days\n*The average vote was 4 days*"
+      let!(:estimate3) { FactoryBot.create(:estimate, number: 3, poker_session: poker_session, user: user1) }
+      let!(:estimate3_5) { FactoryBot.create(:estimate, number: 3.5, poker_session: poker_session, user: user2) }
+
+      it 'will return the correct text' do
+        poker_session.complete_session
+        expect(poker_session.complete_session_text).to eq "*Testing poker sessions*\njerome voted 3 days and callum voted 3.5 days\n*The average vote was 3.5 days*"
+      end
+    end
+
+    context 'with a whole number average' do
+      let!(:estimate) { FactoryBot.create(:estimate, number: 3, poker_session: poker_session, user: user1) }
+
+      it 'will return the correct text' do
+        poker_session.complete_session
+        expect(poker_session.complete_session_text).to eq "*Testing poker sessions*\njerome voted 3 days\n*The average vote was 3 days*"
+      end
     end
   end
 end
-


### PR DESCRIPTION
Timeboxes introduced decimals to a column that was previously just
integers. Decimal day estimates were being converted to integers and
losing their real value.

This commit changes the integer column values to decimals, and adds some
handling of displaying decimal calues as text