### PR TITLE
Multiple sessions and channels

### DIFF
--- a/app/controllers/poker_sessions_controller.rb
+++ b/app/controllers/poker_sessions_controller.rb
@@ -1,9 +1,6 @@
 class PokerSessionsController < ApplicationController
   def create
     story_name = params[:text]
-    puts "======="
-    puts params
-    puts "======="
     timebox = story_name.downcase.include?('timebox')
     if timebox
       poker_session = PokerSession::Timebox.new(story_name: story_name)
@@ -12,7 +9,7 @@ class PokerSessionsController < ApplicationController
     end
 
     if poker_session.save
-      PokerSlackMessage.new(story_name, poker_session).send
+      PokerSlackMessage.new(story_name, poker_session, params[:response_url]).send
       head 200
     else
       head 422

--- a/app/controllers/poker_sessions_controller.rb
+++ b/app/controllers/poker_sessions_controller.rb
@@ -1,6 +1,9 @@
 class PokerSessionsController < ApplicationController
   def create
     story_name = params[:text]
+    puts "======="
+    puts params
+    puts "======="
     timebox = story_name.downcase.include?('timebox')
     if timebox
       poker_session = PokerSession::Timebox.new(story_name: story_name)

--- a/lib/poker_slack_message.rb
+++ b/lib/poker_slack_message.rb
@@ -1,10 +1,11 @@
 class PokerSlackMessage
-  attr_reader :story_name, :poker_session
+  attr_reader :story_name, :poker_session, :slack_url
   MAX_ACTIONS_PER_ATTACHMENT = 5
 
-  def initialize(story_name, poker_session)
+  def initialize(story_name, poker_session, slack_url)
     @story_name = story_name
     @poker_session = poker_session
+    @slack_url = slack_url
   end
 
   Attachment = Struct.new(:name, :text, :type, :value)
@@ -62,15 +63,12 @@ class PokerSlackMessage
   def request
     {
       text: story_name,
+      response_type: 'in_channel',
       attachments: attachments
     }
   end
 
   def send
     RestClient.post(slack_url, request.to_json)
-  end
-
-  def slack_url
-    ENV['SLACK_HOOK_URL']
   end
 end

--- a/lib/poker_slack_message.rb
+++ b/lib/poker_slack_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PokerSlackMessage
   attr_reader :story_name, :poker_session, :slack_url
   MAX_ACTIONS_PER_ATTACHMENT = 5
@@ -22,9 +24,7 @@ class PokerSlackMessage
       }
       attachment[:actions] = action_group
 
-      if i == 0
-        attachment[:text] = text
-      end
+      attachment[:text] = text if i == 0
 
       arr << attachment
     end
@@ -44,20 +44,19 @@ class PokerSlackMessage
       type: 'button',
       value: '?'
     },
-    {
-      name: 'end',
-      text: 'End',
-      type: 'button',
-      style: 'primary',
-      value: 'end',
-      confirm: {
-        title: "Are you sure?",
-        text: "This will end the poker session and total results!",
-        ok_text: "Yes",
-        dismiss_text: "No"
-      }
-    }
-    ]
+     {
+       name: 'end',
+       text: 'End',
+       type: 'button',
+       style: 'primary',
+       value: 'end',
+       confirm: {
+         title: 'Are you sure?',
+         text: 'This will end the poker session and total results!',
+         ok_text: 'Yes',
+         dismiss_text: 'No'
+       }
+     }]
   end
 
   def request


### PR DESCRIPTION
We currently can send messages to only certain channels on
slack, however, we want to be able to send messages on multiple
channels with multiple sessions running. These changes aim
to address that. 

**Testing Instructions** 
 -  Use the URL on an install of the planning poker app.
 - **Test app url:** https://planning-poks.herokuapp.com/